### PR TITLE
[Dependencies] Support react and react-dom 16 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "invariant": "^2.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   }
 }


### PR DESCRIPTION
Hi there, thanks for creating this component! Using it in a project with React 16+ will cause this warning: 

```
warning "react-ios-switch@0.1.10" has incorrect peer dependency "react-dom@^0.14.0 || ^15.0.0".
```

This PR updates the peerDependencies to satisfy this warning + the component seems to be compatible with 16 (unless I'm mistaken).

Thanks for reviewing!